### PR TITLE
PoC: move constants to individual files to keep business logic clean

### DIFF
--- a/src/components/UIElements/MediaEmbed.vue
+++ b/src/components/UIElements/MediaEmbed.vue
@@ -39,6 +39,7 @@
 import fs from 'fs'
 import path from 'path'
 import Resources from "@/resources.js"
+import { INDEXED_FLASH_PROPS } from '@/constants.js'
 
 export default {
   name: "MediaEmbed",
@@ -46,127 +47,7 @@ export default {
   emits: ['blockedevent'], 
   data() {
     return {
-      indexedFlashProps: {
-        // CAPTCHA GENERATOR
-        "captchas": {width: 1100, height: 600},
-        // SWEET CRED
-        "kidshome": {width: 800, height: 600},
-        // CLOCKS
-        "03848": {height: 1612},
-        "03857": {height: 1612},
-        "06649": {height: 1612},
-        // GENESIS FROG 
-        "04015": {height: 800},
-        // JOHN/JANE CURSOR
-        "05721": {height: 800},
-        "06202": {height: 800},
-        // SCRATCH ALTERNIA 
-        "04050": {height: 650},
-        // A6A6I1 SELECTION SCREEN
-        "06277": {height: 650},
-        // A6A6I5 SELECTION SCREENS
-        "07482": {height: 650},
-        "07668": {height: 650},
-        "07677": {height: 650},
-        "07682": {height: 650},
-        "07689": {height: 650},
-        "07692": {height: 650},
-        "07696": {height: 650},
-        "07709": {height: 650},
-        "07721": {height: 650},
-        "07729": {height: 650},
-        "07762": {height: 650},
-        "07800": {height: 650},
-        "07905": {height: 650},        
-        // TYPHEUS, YALDABOATH
-        "05994": {height: 1400},
-        "07083": {height: 1400},
-        // HOMOSUCK ANTHEM
-        "06240": {
-          bgcolor: '#073C00',
-          height: 576
-        },
-        // CASCADE
-        "04106": {
-          bgcolor: '#262626',
-          width: 950, height: 650
-        },
-        "cascade": {
-          bgcolor: '#262626',
-          width: 950, height: 650
-        },
-        // DOTA
-        "04812": {
-          bgcolor: '#000',
-          width: 950,
-          height: 650
-        },
-        // A6A6I4 FULLPAGERS
-        "07095": {width: 950, height: 650, rawStyle: 'position:relative;top:-21px;'},
-        "07122": {width: 950, height: 650, rawStyle: 'position:relative;top:-19px;'},
-        // SHE'S 8ACK
-        "07402": {width: 950, height: 650},          
-        // A6A6I1 SELECTION SCREENS
-        "06379": {
-          bgcolor: '#C6C6C6',
-          width: 950, height: 600
-        },
-        "06394": {
-          bgcolor: '#C6C6C6',
-          width: 950, height: 600
-        },
-        "06398": {
-          bgcolor: '#C6C6C6',
-          width: 950, height: 600
-        },
-        "06402": {
-          bgcolor: '#C6C6C6',
-          width: 950, height: 600
-        },
-        "06413": {
-          bgcolor: '#C6C6C6',
-          width: 950, height: 600
-        },
-        // VRISKAGRAM 
-        "07445": {
-          bgcolor: '#C6C6C6',
-          width: 950, height: 600
-        },
-
-        // REMEM8ER
-        "07953": {
-          bgcolor: '#C6C6C6',
-          width: 950,
-          height: 675
-        },
-        // HUGBUNP
-        "07921": {
-          width: 950,
-          height: 700
-        },
-        // GOLD PILOT
-        "A6A6I1": {
-          filename: "A6A6I1",
-          bgcolor: '#C6C6C6',
-          width: 950,
-          height: 750
-        },
-        // GAME OVER
-        "06898": {
-          bgcolor: '#042300',
-          width: 950, height: 786
-        },
-        // CROWBARS
-        "05492": {width: 950, height: 1160},
-        "05777": {width: 950, height: 1160},
-        // TRICKSTER BANNER
-        "menu": {width: 950, height: 20},
-        // TRICKSTER BANNER
-        "echidna": {width: 30, height: 30},
-        "Cheerfulbear%20-%20PLAY%20ME": {width: 1120, height: 750},
-        "Dear%20Andrew": {width: 1120, height: 750},
-        "SBaHJ%20Origins": {width: 1120, height: 750}
-      },
+      indexedFlashProps: INDEXED_FLASH_PROPS,
       gameOver: {
         count: 0,
         steps: [22433, 82300, 94800, 118566, 143930, 146973, 224876]
@@ -231,7 +112,7 @@ export default {
         '11931': -125,
         '17445': 1700,
         'A6A6I1': -100,
-        'darkcage': 350,
+        'darkcage': 350
       },
       pauseAt: {
         "08080": 18
@@ -268,7 +149,7 @@ export default {
     },
     flashProps() {
       // ID, before any underscores
-      let filename = path.parse(this.url).name.split("_")[0]
+      const filename = path.parse(this.url).name.split("_")[0]
       this.$logger.info("Getting flash props for", filename, this.url)
 
       const defaultProps = {
@@ -279,7 +160,7 @@ export default {
         rawStyle: ''
       }
 
-      let customProps = this.indexedFlashProps[filename] || {}
+      const customProps = this.indexedFlashProps[filename] || {}
 
       if (Object.keys(customProps).length)
         this.$logger.info("Custom props for flash", filename, customProps)

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,214 @@
+export const INDEXED_FLASH_PROPS = {
+  // CAPTCHA GENERATOR
+  "captchas": {
+    width: 1100,
+    height: 600
+  },
+  // SWEET CRED
+  "kidshome": {
+    width: 800,
+    height: 600
+  },
+  // CLOCKS
+  "03848": {
+    height: 1612
+  },
+  "03857": {
+    height: 1612
+  },
+  "06649": {
+    height: 1612
+  },
+  // GENESIS FROG 
+  "04015": {
+    height: 800
+  },
+  // JOHN/JANE CURSOR
+  "05721": {
+    height: 800
+  },
+  "06202": {
+    height: 800
+  },
+  // SCRATCH ALTERNIA 
+  "04050": {
+    height: 650
+  },
+  // A6A6I1 SELECTION SCREEN
+  "06277": {
+    height: 650
+  },
+  // A6A6I5 SELECTION SCREENS
+  "07482": {
+    height: 650
+  },
+  "07668": {
+    height: 650
+  },
+  "07677": {
+    height: 650
+  },
+  "07682": {
+    height: 650
+  },
+  "07689": {
+    height: 650
+  },
+  "07692": {
+    height: 650
+  },
+  "07696": {
+    height: 650
+  },
+  "07709": {
+    height: 650
+  },
+  "07721": {
+    height: 650
+  },
+  "07729": {
+    height: 650
+  },
+  "07762": {
+    height: 650
+  },
+  "07800": {
+    height: 650
+  },
+  "07905": {
+    height: 650
+  },
+  // TYPHEUS, YALDABOATH
+  "05994": {
+    height: 1400
+  },
+  "07083": {
+    height: 1400
+  },
+  // HOMOSUCK ANTHEM
+  "06240": {
+    bgcolor: '#073C00',
+    height: 576
+  },
+  // CASCADE
+  "04106": {
+    bgcolor: '#262626',
+    width: 950,
+    height: 650
+  },
+  "cascade": {
+    bgcolor: '#262626',
+    width: 950,
+    height: 650
+  },
+  // DOTA
+  "04812": {
+    bgcolor: '#000',
+    width: 950,
+    height: 650
+  },
+  // A6A6I4 FULLPAGERS
+  "07095": {
+    width: 950,
+    height: 650,
+    rawStyle: 'position:relative;top:-21px;'
+  },
+  "07122": {
+    width: 950,
+    height: 650,
+    rawStyle: 'position:relative;top:-19px;'
+  },
+  // SHE'S 8ACK
+  "07402": {
+    width: 950,
+    height: 650
+  },
+  // A6A6I1 SELECTION SCREENS
+  "06379": {
+    bgcolor: '#C6C6C6',
+    width: 950,
+    height: 600
+  },
+  "06394": {
+    bgcolor: '#C6C6C6',
+    width: 950,
+    height: 600
+  },
+  "06398": {
+    bgcolor: '#C6C6C6',
+    width: 950,
+    height: 600
+  },
+  "06402": {
+    bgcolor: '#C6C6C6',
+    width: 950,
+    height: 600
+  },
+  "06413": {
+    bgcolor: '#C6C6C6',
+    width: 950,
+    height: 600
+  },
+  // VRISKAGRAM 
+  "07445": {
+    bgcolor: '#C6C6C6',
+    width: 950,
+    height: 600
+  },
+
+  // REMEM8ER
+  "07953": {
+    bgcolor: '#C6C6C6',
+    width: 950,
+    height: 675
+  },
+  // HUGBUNP
+  "07921": {
+    width: 950,
+    height: 700
+  },
+  // GOLD PILOT
+  "A6A6I1": {
+    filename: "A6A6I1",
+    bgcolor: '#C6C6C6',
+    width: 950,
+    height: 750
+  },
+  // GAME OVER
+  "06898": {
+    bgcolor: '#042300',
+    width: 950,
+    height: 786
+  },
+  // CROWBARS
+  "05492": {
+    width: 950,
+    height: 1160
+  },
+  "05777": {
+    width: 950,
+    height: 1160
+  },
+  // TRICKSTER BANNER
+  "menu": {
+    width: 950,
+    height: 20
+  },
+  // TRICKSTER BANNER
+  "echidna": {
+    width: 30,
+    height: 30
+  },
+  "Cheerfulbear%20-%20PLAY%20ME": {
+    width: 1120,
+    height: 750
+  },
+  "Dear%20Andrew": {
+    width: 1120,
+    height: 750
+  },
+  "SBaHJ%20Origins": {
+    width: 1120,
+    height: 750
+  }
+}


### PR DESCRIPTION
Currently components have big groups of constants declared as data properties, making the code harder to parse than it already is, but Vue allows us to keep those elsewhere. This is a proof of concept that can be applied to other big sets of constants (see https://github.com/recordcrash/homestuck-online/tree/master/src/constants for a partial implementation).

I don't really know if it's better to create a constants folder with multiple files or just one big constants.js with comments. This project seems to prefer the latter, so that's up to Bambosh or Gio to decide.

No need to merge, this is just a quick proof of concept.