### PR TITLE
mods: fix storing `false`

### DIFF
--- a/src/mods.js
+++ b/src/mods.js
@@ -474,10 +474,10 @@ async function buildApi(mod) {
         } else {
           const v = store_mods.get(getModStoreKey(mod._id, k), default_)
           this_store_cache[k] = (v == undefined ? cached_undefined : v)
-          return v || default_
+          return v
         }
       },
-      has: (k) => this_store_cache[k] || store_mods.has(getModStoreKey(mod._id, k)),
+      has: (k) => this_store_cache[k] != undefined || store_mods.has(getModStoreKey(mod._id, k)),
       delete: (k) => {
         delete this_store_cache[k]
         store_mods.delete(getModStoreKey(mod._id, k))


### PR DESCRIPTION
`store.has` was broken in 9aa2f71e16374e17354b957af1606593ec935998, such that a cached stored value of `false` is ignored.

`store.get` was broken in a64ec80332146e424dd7c218cb97ae055d4be4ac, such that an uncached stored value of `false` is ignored.